### PR TITLE
 Numerical `setImage` / `operator()` tests for each feature evaluator

### DIFF
--- a/traincascade/test/test_features.cpp
+++ b/traincascade/test/test_features.cpp
@@ -234,3 +234,207 @@ TEST_CASE("CvFeatureEvaluator::setImage: stores class label at the given sample 
   // Assert
   CHECK(evaluator.getCls(2) == doctest::Approx(1.0f));
 }
+
+// ---------------------------------------------------------------------------
+// setImage / operator() — numerical tests on synthetic images
+//
+// These tests exercise the feature-evaluation code path end-to-end:
+//   1. evaluator.init(...)         — generates feature descriptors
+//   2. evaluator.setImage(img, ..) — computes integral images / histograms
+//   3. evaluator(featureIdx, idx)  — evaluates a feature at a sample
+//
+// Each evaluator has a property that holds for any uniform (constant)
+// image, which lets us assert exact numerical values without depending on
+// which feature index corresponds to which geometric layout.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("CvHaarEvaluator::operator(): returns 0 for every feature on a constant image") {
+  // Arrange: a constant image has zero variance, so calcNormFactor() is 0
+  // and CvHaarEvaluator::operator() short-circuits to 0.0f.
+  CvHaarFeatureParams params(CvHaarFeatureParams::BASIC);
+  params.maxCatCount = 0;
+  params.featSize = 1;
+  CvHaarEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(24, 24));
+  cv::Mat constImg(24, 24, CV_8UC1, cv::Scalar(128));
+
+  // Act
+  evaluator.setImage(constImg, /*clsLabel=*/1, /*idx=*/0);
+
+  // Assert: every Haar feature evaluates to exactly 0 on a flat patch.
+  bool allZero = true;
+  for (int fi = 0; fi < evaluator.getNumFeatures(); ++fi) {
+    if (evaluator(fi, 0) != 0.0f) {
+      allZero = false;
+      break;
+    }
+  }
+  CHECK(allZero);
+  CHECK(evaluator.getNumFeatures() > 0);
+}
+
+TEST_CASE("CvHaarEvaluator::operator(): returns at least one non-zero value on a textured image") {
+  // Arrange: a vertical step edge has non-zero variance and breaks the
+  // Haar feature symmetry — at least one feature must produce a non-zero
+  // response, otherwise something is wrong with setImage / operator().
+  CvHaarFeatureParams params(CvHaarFeatureParams::BASIC);
+  CvHaarEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(24, 24));
+  cv::Mat img(24, 24, CV_8UC1, cv::Scalar(0));
+  img(cv::Rect(12, 0, 12, 24)).setTo(cv::Scalar(255));  // vertical step edge
+
+  // Act
+  evaluator.setImage(img, /*clsLabel=*/1, /*idx=*/0);
+
+  // Assert
+  bool foundNonZero = false;
+  for (int fi = 0; fi < evaluator.getNumFeatures() && !foundNonZero; ++fi) {
+    if (evaluator(fi, 0) != 0.0f) {
+      foundNonZero = true;
+    }
+  }
+  CHECK(foundNonZero);
+}
+
+TEST_CASE("CvHaarEvaluator::setImage: ALL mode also computes the tilted integral") {
+  // Arrange: ALL mode adds tilted features; the evaluator must still return
+  // 0 on a constant image because the tilted integral is also flat.
+  CvHaarFeatureParams params(CvHaarFeatureParams::ALL);
+  CvHaarEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(24, 24));
+  cv::Mat constImg(24, 24, CV_8UC1, cv::Scalar(64));
+
+  // Act
+  evaluator.setImage(constImg, /*clsLabel=*/0, /*idx=*/0);
+
+  // Assert: pick a couple of feature indices spanning the full range.
+  REQUIRE(evaluator.getNumFeatures() > 1);
+  CHECK(evaluator(0, 0) == doctest::Approx(0.0f));
+  CHECK(evaluator(evaluator.getNumFeatures() - 1, 0) == doctest::Approx(0.0f));
+  // And the class label was stored.
+  CHECK(evaluator.getCls(0) == doctest::Approx(0.0f));
+}
+
+TEST_CASE("CvLBPEvaluator::operator(): returns 255 for every feature on a constant image") {
+  // Arrange: on a uniform image every 3x3 block sum equals cval, so every
+  // one of the 8 LBP comparisons (`>= cval`) is true. Result: 0xFF == 255.
+  CvLBPFeatureParams params;
+  CvLBPEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(24, 24));
+  cv::Mat constImg(24, 24, CV_8UC1, cv::Scalar(50));
+
+  // Act
+  evaluator.setImage(constImg, /*clsLabel=*/1, /*idx=*/0);
+
+  // Assert
+  REQUIRE(evaluator.getNumFeatures() > 0);
+  bool allMax = true;
+  for (int fi = 0; fi < evaluator.getNumFeatures(); ++fi) {
+    if (evaluator(fi, 0) != 255.0f) {
+      allMax = false;
+      break;
+    }
+  }
+  CHECK(allMax);
+}
+
+TEST_CASE("CvLBPEvaluator::operator(): produces values < 255 on a non-constant image") {
+  // Arrange: a horizontal step edge breaks the >= cval invariant for at
+  // least one comparison in many features.
+  CvLBPFeatureParams params;
+  CvLBPEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(24, 24));
+  cv::Mat img(24, 24, CV_8UC1, cv::Scalar(0));
+  img(cv::Rect(0, 12, 24, 12)).setTo(cv::Scalar(200));
+
+  // Act
+  evaluator.setImage(img, /*clsLabel=*/1, /*idx=*/0);
+
+  // Assert: at least one feature must encode a bit pattern other than 0xFF.
+  bool foundNonMax = false;
+  for (int fi = 0; fi < evaluator.getNumFeatures() && !foundNonMax; ++fi) {
+    if (evaluator(fi, 0) < 255.0f) {
+      foundNonMax = true;
+    }
+  }
+  CHECK(foundNonMax);
+}
+
+TEST_CASE("CvLBPEvaluator: setImage isolates samples by index") {
+  // Arrange: write two different images at indices 0 and 1, then verify
+  // each sample's evaluation reflects the image stored at that index.
+  CvLBPFeatureParams params;
+  CvLBPEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/2, cv::Size(24, 24));
+  cv::Mat constImg(24, 24, CV_8UC1, cv::Scalar(80));
+  cv::Mat textImg(24, 24, CV_8UC1, cv::Scalar(0));
+  textImg(cv::Rect(0, 12, 24, 12)).setTo(cv::Scalar(200));
+
+  // Act
+  evaluator.setImage(constImg, /*clsLabel=*/0, /*idx=*/0);
+  evaluator.setImage(textImg, /*clsLabel=*/1, /*idx=*/1);
+
+  // Assert: sample 0 (constant) -> all features == 255; sample 1 (textured)
+  // -> at least one feature differs from sample 0.
+  REQUIRE(evaluator.getNumFeatures() > 0);
+  CHECK(evaluator(0, 0) == doctest::Approx(255.0f));
+  bool sample1HasDifferentValue = false;
+  for (int fi = 0; fi < evaluator.getNumFeatures(); ++fi) {
+    if (evaluator(fi, 1) != evaluator(fi, 0)) {
+      sample1HasDifferentValue = true;
+      break;
+    }
+  }
+  CHECK(sample1HasDifferentValue);
+  CHECK(evaluator.getCls(0) == doctest::Approx(0.0f));
+  CHECK(evaluator.getCls(1) == doctest::Approx(1.0f));
+}
+
+TEST_CASE("CvHOGEvaluator::operator(): returns 0 for every component on a constant image") {
+  // Arrange: a constant image has zero gradients, so every HOG bin is 0
+  // and the implementation's `res > 0.001f` guard returns 0.0f.
+  CvHOGFeatureParams params;
+  CvHOGEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(32, 32));
+  cv::Mat constImg(32, 32, CV_8UC1, cv::Scalar(100));
+
+  // Act
+  evaluator.setImage(constImg, /*clsLabel=*/1, /*idx=*/0);
+
+  // Assert: getNumFeatures() returns the number of feature blocks, while
+  // operator() is indexed by varIdx in [0, numFeatures * N_BINS * N_CELLS).
+  REQUIRE(evaluator.getNumFeatures() > 0);
+  const int totalVars = evaluator.getNumFeatures() * N_BINS * N_CELLS;
+  bool allZero = true;
+  for (int v = 0; v < totalVars; ++v) {
+    if (evaluator(v, 0) != 0.0f) {
+      allZero = false;
+      break;
+    }
+  }
+  CHECK(allZero);
+}
+
+TEST_CASE("CvHOGEvaluator::operator(): produces at least one non-zero on a textured image") {
+  // Arrange
+  CvHOGFeatureParams params;
+  CvHOGEvaluator evaluator;
+  evaluator.init(&params, /*maxSampleCount=*/1, cv::Size(32, 32));
+  cv::Mat img(32, 32, CV_8UC1, cv::Scalar(0));
+  img(cv::Rect(16, 0, 16, 32)).setTo(cv::Scalar(255));  // strong vertical edge
+
+  // Act
+  evaluator.setImage(img, /*clsLabel=*/1, /*idx=*/0);
+
+  // Assert
+  REQUIRE(evaluator.getNumFeatures() > 0);
+  const int totalVars = evaluator.getNumFeatures() * N_BINS * N_CELLS;
+  bool foundNonZero = false;
+  for (int v = 0; v < totalVars && !foundNonZero; ++v) {
+    if (evaluator(v, 0) > 0.0f) {
+      foundNonZero = true;
+    }
+  }
+  CHECK(foundNonZero);
+}
+


### PR DESCRIPTION
## Summary

The existing feature tests verified construction, `init` and feature
counts, but never **evaluated** a feature on a real image. This MR adds
8 numerical tests that drive the full pipeline of every concrete
evaluator (`CvHaarEvaluator`, `CvLBPEvaluator`, `CvHOGEvaluator`):

```
init() → setImage() → operator()(featureIdx, sampleIdx)
```

The tests use synthetic images (constant patches and step edges) and
assert closed-form invariants that hold regardless of which feature
index corresponds to which geometric layout, so they remain meaningful
without hard-coding implementation-specific feature ordering.

Library line coverage rises from **42.4% → 44.4%**, driven primarily by
`HOGfeatures.cpp` going from **28% → 77%** (the entire integral
histogram + feature evaluation path was previously untested).

## Changes

### `traincascade/test/test_features.cpp`
8 new test cases appended, all following the existing **Arrange / Act /
Assert** pattern with comments per step:

| Evaluator | Invariant exploited | Tests added |
|---|---|---|
| **Haar** | Flat image → variance = 0 → `normfactor = 0` → `operator()` short-circuits to `0.0f` for every feature | constant returns 0 (BASIC), vertical edge produces ≥1 nonzero, ALL mode flat → 0 (also exercises the tilted-integral branch in `setImage`) |
| **LBP** | Flat image → all 8 block sums equal `cval` → all 8 `>= cval` comparisons true → result `0xFF = 255` | constant returns 255, horizontal edge produces ≥1 value `<255`, two-sample isolation by index |
| **HOG** | Flat image → all gradients 0 → bin sums fail `> 0.001f` guard → `0.0f` for every variable | constant returns 0 across all `numFeatures × N_BINS × N_CELLS` vars, vertical edge produces ≥1 nonzero |

Inner loops use a fail-fast accumulator into a single `CHECK` so the
doctest assertion counter stays sane (291 total, not 170k+).

## Why these invariants?

Each evaluator has a property that holds for any uniform input:

- **Haar** uses a normalization factor derived from the image variance.
  On a constant patch the variance is zero, the implementation
  short-circuits, and every feature returns exactly 0. Any non-zero
  output on a textured image therefore proves `setImage` actually
  populated the integral image and `operator()` is using it.
- **LBP** compares each surrounding 3×3 block sum to the center block.
  Equal sums make every comparison `true`, producing the maximum bit
  pattern `0xFF`. A non-`0xFF` output on a textured image proves the
  pipeline is working end-to-end.
- **HOG** computes per-bin gradient histograms; on a flat image every
  bin is zero and the implementation's `res > 0.001f` guard returns
  `0.0f` everywhere. A non-zero output on an edge image proves
  `integralHistogram`, normalization and `Feature::calc` are wired up.

Using closed-form invariants instead of golden values keeps the tests
robust against benign reordering of generated features.

## Test results

```
[doctest] test cases:  88 |  88 passed | 0 failed | 0 skipped
[doctest] assertions: 291 | 291 passed | 0 failed |
[doctest] Status: SUCCESS!

ctest: 100% tests passed, 0 tests failed out of 1
```

## Coverage impact (`traincascade/lib/`)

| Metric    | Before | After  |
| --------- | ------ | ------ |
| Lines     | 42.4% (1984 / 4676) | **44.4%** (2076 / 4676) |
| Functions | 77.5% (200 / 258)   | **79.1%** (204 / 258)   |
| Branches  | 27.7% (1388 / 5006) | **28.8%** (1442 / 5006) |

Per-file gains:

| File | Before → After |
|---|---|
| `HOGfeatures.cpp` | 28% → **77%** ⭐ |
| `HOGfeatures.h` (inline `operator()` / `Feature::calc`) | 7% → **100%** |
| `haarfeatures.cpp` | 73% → **75%** |
| `lbpfeatures.h` (inline `Feature::calc`) | already 100%, now exercised on real data |

The HOG jump is the key win: previously no test ever called
`CvHOGEvaluator::setImage`, so the entire `integralHistogram`,
gradient-bin accumulation and normalization paths were dark. They are
now covered on both the zero-gradient short-circuit path and the normal
evaluation path.

## Risks / Notes

- All tests use in-memory `cv::Mat` images — no filesystem I/O, no test
  fixtures.
- Runtime contribution is well under one second.
- No changes to library code.

## Checklist

- [x] All 88 tests pass locally (`ctest --output-on-failure`)
- [x] AAA pattern with comments in every test
- [x] Happy paths and degenerate inputs covered (constant images, edges)
- [x] No new resource files committed
- [x] No changes to library code