### PR TITLE
Add dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Adds dependabot.yml to enable automated dependency updates via GitHub Dependabot.

### What

Configures Dependabot to monitor and automatically open PRs for outdated GitHub Actions versions used across all workflow files.

### Why

The project's CI workflows reference several GitHub Actions by major version tag (`actions/checkout@v6`, `actions/upload-artifact@v7`, `github/codeql-action/*@v4`). Without Dependabot, these are never updated, which can lead to using deprecated or insecure action versions.

### Configuration

- **Ecosystem:** `github-actions`
- **Schedule:** Monthly — keeps maintenance overhead low while still receiving timely security and compatibility updates.

### Affected actions

| Action | Current version |
|---|---|
| `actions/checkout` | `@v6` |
| `actions/upload-artifact` | `@v7` |
| `github/codeql-action/init` | `@v4` |
| `github/codeql-action/analyze` | `@v4` |

Completed: *Check if other files need restoration* (3/3)